### PR TITLE
Update default sampling

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,17 +22,17 @@ Z: <span id="z">0</span>
 </div>
 <div id="settings" style="margin-top:20px;">
     <label>Sample interval (ms):
-        <input type="number" id="sample-interval" value="250" min="10" step="10">
+        <input type="number" id="sample-interval" value="5" min="1" step="1">
     </label>
     <br>
     <label>Samples before fading:
-        <input type="number" id="history-length" value="20" min="1" step="1">
+        <input type="number" id="history-length" value="50" min="1" step="1">
     </label>
 </div>
 <canvas id="debug-canvas" width="300" height="300"></canvas>
 <script>
-let SAMPLE_INTERVAL = 250; // milliseconds
-let HISTORY_LENGTH = 20;
+let SAMPLE_INTERVAL = 5; // milliseconds
+let HISTORY_LENGTH = 50;
 let debugCanvas, debugCtx;
 const samples = [];
 let lastSampleTime = 0;


### PR DESCRIPTION
## Summary
- set default sample interval to 5ms and history length to 50 samples in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68442b6ae600832aae9872a86e526ea6