### PR TITLE
Enhance about page and reposition about button

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
 <body>
 <h1>About Breath Control</h1>
 <p>This app visualizes accelerometer data to help monitor breathing patterns.</p>
+<p><img src="D9487AA8-9281-461A-872F-2E6E1F11F152.png" alt="Breath Control screenshot" style="max-width:100%;height:auto;"></p>
 <p><a href="index.html">Back to app</a></p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,13 +7,17 @@
 <link rel="manifest" href="manifest.json">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <style>
+#header { display:flex; align-items:center; justify-content:space-between; }
 body { font-family: Arial, sans-serif; margin: 40px; }
 #values { margin-top: 20px; font-size: 1.2em; }
 #debug-canvas { display: block; margin-top: 20px; background: #eee; border: 1px solid #ccc; }
 </style>
 </head>
 <body>
-<h1>Breath Control</h1>
+<div id="header">
+    <h1>Breath Control</h1>
+    <button id="about-button" onclick="window.location.href='about.html'">About</button>
+</div>
 <canvas id="debug-canvas" width="300" height="300"></canvas>
 <p id="status">Awaiting permission for motion sensors...</p>
 <div id="values">
@@ -50,7 +54,6 @@ body { font-family: Arial, sans-serif; margin: 40px; }
         </select>
     </label>
 </div>
-<button id="about-button" onclick="window.location.href='about.html'">About</button>
 <script>
 let SAMPLE_INTERVAL = 5; // milliseconds
 let HISTORY_LENGTH = 50;


### PR DESCRIPTION
## Summary
- embed screenshot in the about page
- place the About button next to the title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844544897b4832a8510370e5c4b755c